### PR TITLE
Reapply Nachtzuster Commit 28bfe59 "fix: rtsps is rtsp too"

### DIFF
--- a/scripts/birdnet_recording.sh
+++ b/scripts/birdnet_recording.sh
@@ -33,7 +33,7 @@ if [ ! -z $RTSP_STREAM ];then
     # Loop over the streams
     for i in "${RTSP_STREAMS_EXPLODED_ARRAY[@]}"
     do
-      if [[ "$i" == "rtsp://"* ]]; then
+      if [[ "$i" =~ ^rtsps?:// ]]; then
         [ $FFMPEG_VERSION -lt 5 ] && PARAM=-stimeout || PARAM=-timeout
         TIMEOUT_PARAM="$PARAM 10000000"
       elif [[ "$i" =~ ^[a-z]+:// ]]; then


### PR DESCRIPTION
Reapply commit https://github.com/Nachtzuster/BirdNET-Pi/commit/28bfe59204b41953883aed0065054e766f1ac4c2 "fix: rtsps is rtsp too" from Nachtzuster.

Got removed in a revert 5 months ago, this breaks RTSPS Streams with error `Option rw_timeout not found.` (this works in Nachtzuster version)