### PR TITLE
feat: show species image for single species views

### DIFF
--- a/scripts/play.php
+++ b/scripts/play.php
@@ -530,12 +530,16 @@ if(!isset($_GET['species']) && !isset($_GET['filename'])){
           ?>
           <td class="spec">
               <button type="submit" name="species" value="<?php echo $birds[$index];?>"><?php echo $birds[$index].$values[$index];?>
-              <img style='display: inline; cursor: pointer; max-width: 12px; max-height: 12px;' src=<?php if($confirmspecies_enabled == 1) { if (in_array(str_replace("'", "", $birds_sciname_name[$index]), $confirmed_species)) {
-                echo "\"images/check.svg\" onclick='confirmspecies(\"".str_replace("'", "", $birds_sciname_name[$index])."\",\"del\")'";
-              } else {
-                echo "\"images/question.svg\" onclick='confirmspecies(\"".str_replace("'", "", $birds_sciname_name[$index])."\",\"add\")'";
-              }}
-              ?>></button>           
+                <img style='display: inline; cursor: pointer; max-width: 12px; max-height: 12px;' <?php
+                if($confirmspecies_enabled == 1) {
+                  if (in_array(str_replace("'", "", $birds_sciname_name[$index]), $confirmed_species)) {
+                    echo "src=\"images/check.svg\" onclick='confirmspecies(\"".str_replace("'", "", $birds_sciname_name[$index])."\",\"del\")'";
+                  } else {
+                    echo "src=\"images/question.svg\" onclick='confirmspecies(\"".str_replace("'", "", $birds_sciname_name[$index])."\",\"add\")'";
+                  }
+                }
+                ?>>
+              </button>
           </td>
           <?php
         } else {
@@ -673,18 +677,39 @@ $sciname = get_sci_name($name);
 $sciname_name = $sciname . '_' . $name;
 $info_url = get_info_url($sciname);
 $url = $info_url['URL'];
-echo "<table>
-  <tr><th>$name<span style=\"font-weight:normal;\">
-  <img style='display: inline; cursor: pointer; max-width: 12px; max-height: 12px;' src=";
-  if ($confirmspecies_enabled == 1) { if (in_array(str_replace("'", "", $sciname_name), $confirmed_species)) {
-    echo "\"images/check.svg\" onclick='confirmspecies(\"".str_replace("'", "", $sciname_name)."\",\"del\")'";
-    } else {
-    echo "\"images/question.svg\" onclick='confirmspecies(\"".str_replace("'", "", $sciname_name)."\",\"add\")'";
-    };};
-echo "><br><i>$sciname</i></span><br>
-    <a href=\"$url\" target=\"_blank\"><img title=\"$url_title\" src=\"images/info.png\" width=\"20\"></a>
-    <a href=\"https://wikipedia.org/wiki/$sciname\" target=\"_blank\"><img title=\"Wikipedia\" src=\"images/wiki.png\" width=\"20\"></a>
-  </th></tr>";
+$url_title = $info_url['TITLE'];
+$image_provider_name = strtolower($config['IMAGE_PROVIDER'] ?? 'wikipedia');
+$image_url = '';
+$image_link = '';
+if ($image_provider_name === 'flickr' && !empty($config['FLICKR_API_KEY'])) {
+  $provider = new Flickr();
+  $cache = $provider->get_image($sciname);
+  $image_url = $cache['image_url'];
+  $image_link = $cache['photos_url'];
+} else {
+  $provider = new Wikipedia();
+  $cache = $provider->get_image($sciname);
+  $image_url = $cache['image_url'];
+  $image_link = $cache['photos_url'];
+}
+echo "<table><tr><th>";
+if (!empty($image_url)) {
+  echo "<a href='$image_link' target='_blank'><img src='$image_url' style='height:50px;width:50px;border-radius:5px;margin-right:5px;' class='img1'></a>";
+}
+echo "$name<span style='font-weight:normal;'>";
+echo "<img style='display: inline; cursor: pointer; max-width: 12px; max-height: 12px;' src=\"";
+if ($confirmspecies_enabled == 1) {
+  if (in_array(str_replace("'", "", $sciname_name), $confirmed_species)) {
+    echo "images/check.svg\" onclick='confirmspecies(\"".str_replace("'", "", $sciname_name)."\",\"del\")'";
+  } else {
+    echo "images/question.svg\" onclick='confirmspecies(\"".str_replace("'", "", $sciname_name)."\",\"add\")'";
+  }
+}
+echo "\"><br><i>$sciname</i></span><br>";
+echo "<a href='$url' target='_blank'><img title='$url_title' src='images/info.png' width='20'></a>";
+echo "<a href='https://wikipedia.org/wiki/$sciname' target='_blank'><img title='Wikipedia' src='images/wiki.png' width='20'></a>";
+echo "</th></tr>";
+
   $iter=0;
   $iter_additional=false;
   while($results=$result2->fetchArray(SQLITE3_ASSOC))

--- a/scripts/stats.php
+++ b/scripts/stats.php
@@ -200,7 +200,24 @@ while($results=$result3->fetchArray(SQLITE3_ASSOC)){
   $info_url = get_info_url($results['Sci_Name']);
   $url = $info_url['URL'];
   $url_title = $info_url['TITLE'];
-  echo str_pad("<h3>$species</h3>
+  $image_url = '';
+  $image_link = '';
+  if ($image_provider_name === 'flickr' && !empty($config['FLICKR_API_KEY'])) {
+    $provider = new Flickr();
+    $cache = $provider->get_image($sciname);
+    $image_url = $cache['image_url'];
+    $image_link = $cache['photos_url'];
+  } else {
+    $provider = new Wikipedia();
+    $cache = $provider->get_image($sciname);
+    $image_url = $cache['image_url'];
+    $image_link = $cache['photos_url'];
+  }
+  $image_html = '';
+  if (!empty($image_url)) {
+    $image_html = "<a href=\"$image_link\" target=\"_blank\"><img src=\"$image_url\" style=\"height:50px;width:50px;border-radius:5px;margin-right:5px;\" class=\"img1\"></a>";
+  }
+  echo str_pad("<h3>$image_html$species</h3>
     <table><tr>
   <td class=\"relative\"><a target=\"_blank\" href=\"index.php?filename=".$results['File_Name']."\"><img title=\"Open in new tab\" class=\"copyimage\" width=25 src=\"images/copy.png\"></a><i>$sciname</i>
   <a href=\"$url\" target=\"_blank\"><img style=\"width: unset !important; display: inline; height: 1em; cursor: pointer;\" title=\"$url_title\" src=\"images/info.png\" width=\"20\"></a>


### PR DESCRIPTION
## Summary
- show a Flickr/Wikipedia image beside species headings on the recordings page
- include species image on species stats view
- restore confirm-species icon on recordings page

## Testing
- `php -l scripts/play.php`
- `php -l scripts/stats.php`
- `pytest` *(fails: fixture 'mocker' not found; FileNotFoundError for test.db)*

------
https://chatgpt.com/codex/tasks/task_e_6893c910dca48325b04fe23f220777e1