### PR TITLE
feat: show species image for single species views

### DIFF
--- a/scripts/play.php
+++ b/scripts/play.php
@@ -220,8 +220,30 @@ if (get_included_files()[0] === __FILE__) {
 }
 
 ?>
+<dialog style="margin-top: 5px;max-height: 95vh;overflow-y: auto;overscroll-behavior:contain" id="attribution-dialog">
+  <h1 id="modalHeading"></h1>
+  <p id="modalText"></p>
+  <button onclick="hideDialog()">Close</button>
+</dialog>
 <script src="static/custom-audio-player.js"></script>
+<script src="static/dialog-polyfill.js"></script>
 <script>
+var dialog = document.querySelector('dialog');
+dialogPolyfill.registerDialog(dialog);
+
+function showDialog() {
+  document.getElementById('attribution-dialog').showModal();
+}
+
+function hideDialog() {
+  document.getElementById('attribution-dialog').close();
+}
+
+function setModalText(iter, title, text, authorlink, photolink, licenseurl) {
+  document.getElementById('modalHeading').innerHTML = "Photo: \"" + decodeURIComponent(title.replaceAll("+"," ")) + "\" Attribution";
+  document.getElementById('modalText').innerHTML = "<div><img style='border-radius:5px;max-height: calc(100vh - 15rem);display: block;margin: 0 auto;' src='" + photolink + "'></div><br><div style='white-space:nowrap'>Image link: <a target='_blank' href=" + text + ">" + text + "</a><br>Author link: <a target='_blank' href=" + authorlink + ">" + authorlink + "</a><br>License URL: <a href=" + licenseurl + " target='_blank'>" + licenseurl + "</a></div>";
+  showDialog();
+}
 
 function deleteDetection(filename,copylink=false) {
   if (confirm("Are you sure you want to delete this detection from the database?") == true) {
@@ -530,12 +552,16 @@ if(!isset($_GET['species']) && !isset($_GET['filename'])){
           ?>
           <td class="spec">
               <button type="submit" name="species" value="<?php echo $birds[$index];?>"><?php echo $birds[$index].$values[$index];?>
-              <img style='display: inline; cursor: pointer; max-width: 12px; max-height: 12px;' src=<?php if($confirmspecies_enabled == 1) { if (in_array(str_replace("'", "", $birds_sciname_name[$index]), $confirmed_species)) {
-                echo "\"images/check.svg\" onclick='confirmspecies(\"".str_replace("'", "", $birds_sciname_name[$index])."\",\"del\")'";
-              } else {
-                echo "\"images/question.svg\" onclick='confirmspecies(\"".str_replace("'", "", $birds_sciname_name[$index])."\",\"add\")'";
-              }}
-              ?>></button>           
+                <img style='display: inline; cursor: pointer; max-width: 12px; max-height: 12px;' <?php
+                if($confirmspecies_enabled == 1) {
+                  if (in_array(str_replace("'", "", $birds_sciname_name[$index]), $confirmed_species)) {
+                    echo "src=\"images/check.svg\" onclick='confirmspecies(\"".str_replace("'", "", $birds_sciname_name[$index])."\",\"del\")'";
+                  } else {
+                    echo "src=\"images/question.svg\" onclick='confirmspecies(\"".str_replace("'", "", $birds_sciname_name[$index])."\",\"add\")'";
+                  }
+                }
+                ?>>
+              </button>
           </td>
           <?php
         } else {
@@ -673,18 +699,53 @@ $sciname = get_sci_name($name);
 $sciname_name = $sciname . '_' . $name;
 $info_url = get_info_url($sciname);
 $url = $info_url['URL'];
-echo "<table>
-  <tr><th>$name<span style=\"font-weight:normal;\">
-  <img style='display: inline; cursor: pointer; max-width: 12px; max-height: 12px;' src=";
-  if ($confirmspecies_enabled == 1) { if (in_array(str_replace("'", "", $sciname_name), $confirmed_species)) {
-    echo "\"images/check.svg\" onclick='confirmspecies(\"".str_replace("'", "", $sciname_name)."\",\"del\")'";
-    } else {
-    echo "\"images/question.svg\" onclick='confirmspecies(\"".str_replace("'", "", $sciname_name)."\",\"add\")'";
-    };};
-echo "><br><i>$sciname</i></span><br>
-    <a href=\"$url\" target=\"_blank\"><img title=\"$url_title\" src=\"images/info.png\" width=\"20\"></a>
-    <a href=\"https://wikipedia.org/wiki/$sciname\" target=\"_blank\"><img title=\"Wikipedia\" src=\"images/wiki.png\" width=\"20\"></a>
-  </th></tr>";
+$url_title = $info_url['TITLE'];
+$image_provider_name = strtolower($config['IMAGE_PROVIDER'] ?? 'wikipedia');
+$image_url = '';
+$image_link = '';
+$image_author = '';
+$license_url = '';
+$image_title = '';
+if ($image_provider_name === 'flickr' && !empty($config['FLICKR_API_KEY'])) {
+  $provider = new Flickr();
+  $cache = $provider->get_image($sciname);
+  $image_url = $cache['image_url'];
+  $image_link = $cache['photos_url'];
+  $image_author = $cache['author_url'];
+  $license_url = $cache['license_url'];
+  $image_title = $cache['title'];
+} else {
+  $provider = new Wikipedia();
+  $cache = $provider->get_image($sciname);
+  $image_url = $cache['image_url'];
+  $image_link = $cache['photos_url'];
+  $image_author = $cache['author_url'];
+  $license_url = $cache['license_url'];
+  $image_title = $cache['title'];
+}
+echo "<table><tr><th>";
+if (!empty($image_url)) {
+  $img = htmlspecialchars($image_url, ENT_QUOTES);
+  $link = htmlspecialchars($image_link, ENT_QUOTES);
+  $author = htmlspecialchars($image_author, ENT_QUOTES);
+  $license = htmlspecialchars($license_url, ENT_QUOTES);
+  $title = urlencode($image_title);
+  echo "<span style='cursor:pointer;' onclick=\"setModalText(0,'$title','$link','$author','$img','$license')\"><img src='$img' style='height:50px;width:50px;border-radius:5px;margin-right:5px;' class='img1'></span>";
+}
+echo "$name<span style='font-weight:normal;'>";
+echo "<img style='display: inline; cursor: pointer; max-width: 12px; max-height: 12px;' src=\"";
+if ($confirmspecies_enabled == 1) {
+  if (in_array(str_replace("'", "", $sciname_name), $confirmed_species)) {
+    echo "images/check.svg\" onclick='confirmspecies(\"".str_replace("'", "", $sciname_name)."\",\"del\")'";
+  } else {
+    echo "images/question.svg\" onclick='confirmspecies(\"".str_replace("'", "", $sciname_name)."\",\"add\")'";
+  }
+}
+echo "\"><br><i>$sciname</i></span><br>";
+echo "<a href='$url' target='_blank'><img title='$url_title' src='images/info.png' width='20'></a>";
+echo "<a href='https://wikipedia.org/wiki/$sciname' target='_blank'><img title='Wikipedia' src='images/wiki.png' width='20'></a>";
+echo "</th></tr>";
+
   $iter=0;
   $iter_additional=false;
   while($results=$result2->fetchArray(SQLITE3_ASSOC))

--- a/scripts/stats.php
+++ b/scripts/stats.php
@@ -169,9 +169,14 @@ function hideDialog() {
   document.getElementById('attribution-dialog').close();
 }
 
-function setModalText(iter, title, text, authorlink) {
-  document.getElementById('modalHeading').innerHTML = "Photo "+iter+": \""+title+"\" Attribution";
-  document.getElementById('modalText').innerHTML = "<div style='white-space:nowrap'>Image link: <a target='_blank' href="+text+">"+text+"</a><br>Author link: <a target='_blank' href="+authorlink+">"+authorlink+"</a></div>";
+function setModalText(iter, title, text, authorlink, photolink, licenseurl) {
+  document.getElementById('modalHeading').innerHTML = "Photo: \""+decodeURIComponent(title.replaceAll("+"," "))+"\" Attribution";
+  var inner = "<div><img style='border-radius:5px;max-height: calc(100vh - 15rem);display: block;margin: 0 auto;' src='"+photolink+"'></div><br><div style='white-space:nowrap'>Image link: <a target='_blank' href="+text+">"+text+"</a><br>Author link: <a target='_blank' href="+authorlink+">"+authorlink+"</a>";
+  if (licenseurl) {
+    inner += "<br>License URL: <a href="+licenseurl+" target='_blank'>"+licenseurl+"</a>";
+  }
+  inner += "</div>";
+  document.getElementById('modalText').innerHTML = inner;
   showDialog();
 }
 </script>  
@@ -200,7 +205,38 @@ while($results=$result3->fetchArray(SQLITE3_ASSOC)){
   $info_url = get_info_url($results['Sci_Name']);
   $url = $info_url['URL'];
   $url_title = $info_url['TITLE'];
-  echo str_pad("<h3>$species</h3>
+  $image_url = '';
+  $image_link = '';
+  $image_author = '';
+  $license_url = '';
+  $image_title = '';
+  if ($image_provider_name === 'flickr' && !empty($config['FLICKR_API_KEY'])) {
+    $provider = new Flickr();
+    $cache = $provider->get_image($sciname);
+    $image_url = $cache['image_url'];
+    $image_link = $cache['photos_url'];
+    $image_author = $cache['author_url'];
+    $license_url = $cache['license_url'];
+    $image_title = $cache['title'];
+  } else {
+    $provider = new Wikipedia();
+    $cache = $provider->get_image($sciname);
+    $image_url = $cache['image_url'];
+    $image_link = $cache['photos_url'];
+    $image_author = $cache['author_url'];
+    $license_url = $cache['license_url'];
+    $image_title = $cache['title'];
+  }
+  $image_html = '';
+  if (!empty($image_url)) {
+    $img = htmlspecialchars($image_url, ENT_QUOTES);
+    $link = htmlspecialchars($image_link, ENT_QUOTES);
+    $author = htmlspecialchars($image_author, ENT_QUOTES);
+    $license = htmlspecialchars($license_url, ENT_QUOTES);
+    $title = urlencode($image_title);
+    $image_html = "<span style='cursor:pointer;' onclick=\"setModalText(0,'$title','$link','$author','$img','$license')\"><img src=\"$img\" style=\"height:50px;width:50px;border-radius:5px;margin-right:5px;\" class=\"img1\"></span>";
+  }
+  echo str_pad("<h3>$image_html$species</h3>
     <table><tr>
   <td class=\"relative\"><a target=\"_blank\" href=\"index.php?filename=".$results['File_Name']."\"><img title=\"Open in new tab\" class=\"copyimage\" width=25 src=\"images/copy.png\"></a><i>$sciname</i>
   <a href=\"$url\" target=\"_blank\"><img style=\"width: unset !important; display: inline; height: 1em; cursor: pointer;\" title=\"$url_title\" src=\"images/info.png\" width=\"20\"></a>
@@ -226,14 +262,23 @@ while($results=$result3->fetchArray(SQLITE3_ASSOC)){
       $iter++;
       $modaltext = "https://flickr.com/photos/".$val["owner"]."/".$val["id"];
       $authorlink = "https://flickr.com/people/".$val["owner"];
-      $imageurl = 'https://farm' .$val["farm"]. '.static.flickr.com/' .$val["server"]. '/' .$val["id"]. '_'  .$val["secret"].  '.jpg';
-      echo "<span style='cursor:pointer;' onclick='setModalText(".$iter.",\"".$val["title"]."\",\"".$modaltext."\", \"".$authorlink."\")'><img style='vertical-align:top' src=\"$imageurl\"></span>"; 
-    }
+      $imageurl = 'https://farm' .$val["farm"]. '.static.flickr.com/' .$val["server"]. '/' .$val["id"]. '_'  .$val["secret"]. '.jpg';
+      $title = urlencode($val["title"]);
+      $modal = htmlspecialchars($modaltext, ENT_QUOTES);
+      $author = htmlspecialchars($authorlink, ENT_QUOTES);
+      $img = htmlspecialchars($imageurl, ENT_QUOTES);
+      echo "<span style='cursor:pointer;' onclick=\"setModalText(".$iter.",'$title','$modal','$author','$img','')\"><img style='vertical-align:top' src=\"$img\"></span>";
+      }
   } elseif ($image_provider_name === 'wikipedia') {
     $wiki = new Wikipedia();
     $cache = $wiki->get_image($sciname);
     if (!empty($cache['image_url'])) {
-      echo "<span><img style='vertical-align:top' src=\"".$cache['image_url']."\"></span>";
+      $img = htmlspecialchars($cache['image_url'], ENT_QUOTES);
+      $link = htmlspecialchars($cache['photos_url'], ENT_QUOTES);
+      $author = htmlspecialchars($cache['author_url'], ENT_QUOTES);
+      $license = htmlspecialchars($cache['license_url'], ENT_QUOTES);
+      $title = urlencode($cache['title']);
+      echo "<span style='cursor:pointer;' onclick=\"setModalText(0,'$title','$link','$author','$img','$license')\"><img style='vertical-align:top' src=\"$img\"></span>";
     }
   }
 }


### PR DESCRIPTION
## Summary
- show a Flickr/Wikipedia image beside species headings on the recordings page
- include species image on species stats view
- restore confirm-species icon on recordings page
- allow clicking species images to open an attribution popup

## Testing
- `php -l scripts/play.php`
- `php -l scripts/stats.php`
- `pytest` *(fails: ModuleNotFoundError: No module named 'apprise')*

------
https://chatgpt.com/codex/tasks/task_e_6893c910dca48325b04fe23f220777e1