### PR TITLE
Add species images and stats graphs across views

### DIFF
--- a/homepage/static/dark-style.css
+++ b/homepage/static/dark-style.css
@@ -141,13 +141,34 @@ button:hover {
   position: fixed;
   top: 0%;
   left: 50%;
-  width: calc(40% - 2px);
-  height: calc(25% - 2px);
+  width: calc(45% - 2px);
+  height: calc(30% - 2px);
   background-color: #2b2b2b;
   z-index: 9999;
   overflow: auto;
   border-radius: 5px;
   box-shadow: 0 4px 8px #f5f5f5;
+}
+
+.graph-range {
+  text-align: center;
+  font-size: small;
+  margin-top: 4px;
+}
+
+.graph-range span {
+  cursor: pointer;
+  text-decoration: underline;
+  margin: 0 4px;
+}
+
+.species-thumb {
+  float: left;
+  width: 75px;
+  height: 75px;
+  object-fit: cover;
+  margin-right: 5px;
+  cursor: pointer;
 }
 
 .logo img {

--- a/homepage/style.css
+++ b/homepage/style.css
@@ -136,13 +136,34 @@ button:hover {
   position: fixed;
   top: 0%;
   left: 50%;
-  width: calc(40% - 2px);
-  height: calc(25% - 2px);
+  width: calc(45% - 2px);
+  height: calc(30% - 2px);
   background-color: #fff;
   z-index: 9999;
   overflow: auto;
   border-radius: 5px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.graph-range {
+  text-align: center;
+  font-size: small;
+  margin-top: 4px;
+}
+
+.graph-range span {
+  cursor: pointer;
+  text-decoration: underline;
+  margin: 0 4px;
+}
+
+.species-thumb {
+  float: left;
+  width: 75px;
+  height: 75px;
+  object-fit: cover;
+  margin-right: 5px;
+  cursor: pointer;
 }
 
 .logo img {

--- a/scripts/overview.php
+++ b/scripts/overview.php
@@ -686,11 +686,23 @@ function generateMiniGraph(elem, comname, days = 30) {
       document.body.appendChild(chartWindow);
 
 
-            // Create a canvas element for the chart
+      // Create a canvas element for the chart
       var canvas = document.createElement('canvas');
-      canvas.width = chartWindow.offsetWidth;
-      canvas.height = chartWindow.offsetHeight;
       chartWindow.appendChild(canvas);
+
+      // Add range selector
+      var range = document.createElement('div');
+      range.className = 'graph-range';
+      range.innerHTML = "<span data-days='30'>1m</span> | <span data-days='180'>3m</span> | <span data-days='360'>1y</span>";
+      range.addEventListener('click', function(ev) {
+        if (ev.target.dataset.days) {
+          generateMiniGraph(elem, comname, ev.target.dataset.days);
+        }
+      });
+      chartWindow.appendChild(range);
+
+      canvas.width = chartWindow.offsetWidth;
+      canvas.height = chartWindow.offsetHeight - range.offsetHeight;
 
       // Create a new Chart.js chart
       var ctx = canvas.getContext('2d');

--- a/scripts/play.php
+++ b/scripts/play.php
@@ -220,6 +220,9 @@ if (get_included_files()[0] === __FILE__) {
 }
 
 ?>
+<script src="static/dialog-polyfill.js"></script>
+<script src="static/Chart.bundle.js"></script>
+<script src="static/chartjs-plugin-trendline.min.js"></script>
 <script src="static/custom-audio-player.js"></script>
 <script>
 
@@ -441,6 +444,130 @@ function changeDetection(filename,copylink=false) {
   xhttp.open("GET", "play.php?getlabels=true", true);
   xhttp.send();
 }
+
+</script>
+
+<dialog style="margin-top:5px;max-height:95vh;overflow-y:auto;overscroll-behavior:contain" id="attribution-dialog">
+  <h1 id="modalHeading"></h1>
+  <p id="modalText"></p>
+  <button onclick="hideDialog()">Close</button>
+</dialog>
+
+<script>
+var dialog = document.getElementById('attribution-dialog');
+dialogPolyfill.registerDialog(dialog);
+function showDialog() {
+  document.getElementById('attribution-dialog').showModal();
+}
+
+function hideDialog() {
+  document.getElementById('attribution-dialog').close();
+}
+
+function showSpeciesModal(title, text, authorlink, photolink, licenseurl) {
+  document.getElementById('modalHeading').innerHTML = "Photo: \""+decodeURIComponent(title.replaceAll("+"," "))+"\" Attribution";
+  document.getElementById('modalText').innerHTML = "<div><img style='border-radius:5px;max-height: calc(100vh - 15rem);display:block;margin:0 auto;' src='"+photolink+"'></div><br><div style='white-space:nowrap'>Image link: <a target='_blank' href="+text+">"+text+"</a><br>Author link: <a target='_blank' href="+authorlink+">"+authorlink+"</a><br>License URL: <a target='_blank' href="+licenseurl+">"+licenseurl+"</a></div>";
+  showDialog();
+}
+
+function generateMiniGraph(elem, comname, days = 30) {
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', '/todays_detections.php?comname=' + comname + '&days=' + days);
+  xhr.onload = function() {
+    if (xhr.status === 200) {
+      var detections = JSON.parse(xhr.responseText);
+      if (typeof(window.chartWindow) != 'undefined') {
+        document.body.removeChild(window.chartWindow);
+        window.chartWindow = undefined;
+      }
+      var chartWindow = document.createElement('div');
+      chartWindow.className = "chartdiv";
+      document.body.appendChild(chartWindow);
+
+      var canvas = document.createElement('canvas');
+      chartWindow.appendChild(canvas);
+
+      var range = document.createElement('div');
+      range.className = 'graph-range';
+      range.innerHTML = "<span data-days='30'>1m</span> | <span data-days='180'>3m</span> | <span data-days='360'>1y</span>";
+      range.addEventListener('click', function(ev){
+        if (ev.target.dataset.days) {
+          generateMiniGraph(elem, comname, ev.target.dataset.days);
+        }
+      });
+      chartWindow.appendChild(range);
+
+      canvas.width = chartWindow.offsetWidth;
+      canvas.height = chartWindow.offsetHeight - range.offsetHeight;
+
+      var ctx = canvas.getContext('2d');
+      var chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: detections.map(item => item.date),
+          datasets: [{
+            label: 'Detections',
+            data: detections.map(item => item.count),
+            backgroundColor: '#9fe29b',
+            borderColor: '#77c487',
+            borderWidth: 1,
+            lineTension: 0.3,
+            pointRadius: 1,
+            pointHitRadius: 10,
+            trendlineLinear: {
+              style: "rgba(55, 99, 64, 0.5)",
+              lineStyle: "solid",
+              width: 1.5
+            }
+          }]
+        },
+        options: {
+          layout: { padding: { right: 10 } },
+          title: { display: true, text: 'Detections Over ' + days + 'd' },
+          legend: { display: false },
+          scales: {
+            xAxes: [{ display: false, gridLines: { display: false }, ticks: { autoSkip: true, maxTicksLimit: 2 } }],
+            yAxes: [{ gridLines: { display: false }, ticks: { beginAtZero: true, precision: 0, stepSize: 1 } }]
+          }
+        }
+      });
+
+      var buttonRect = elem.getBoundingClientRect();
+      var chartRect = chartWindow.getBoundingClientRect();
+      if (window.innerWidth < 700) {
+        chartWindow.style.left = 'calc(75% - ' + (chartRect.width / 2) + 'px)';
+      } else {
+        chartWindow.style.left = (buttonRect.right + 10) + 'px';
+      }
+      var buttonCenter = buttonRect.top + (buttonRect.height / 2);
+      var chartHeight = chartWindow.offsetHeight;
+      var chartTop = buttonCenter - (chartHeight / 2);
+      chartWindow.style.top = chartTop + 'px';
+
+      var closeButton = document.createElement('button');
+      closeButton.id = "chartcb";
+      closeButton.innerText = 'X';
+      closeButton.style.position = 'absolute';
+      closeButton.style.top = '5px';
+      closeButton.style.right = '5px';
+      closeButton.addEventListener('click', function() {
+        document.body.removeChild(chartWindow);
+        window.chartWindow = undefined;
+      });
+      chartWindow.appendChild(closeButton);
+      window.chartWindow = chartWindow;
+    }
+  };
+  xhr.send();
+}
+
+window.addEventListener('scroll', function() {
+  var charts = document.querySelectorAll('.chartdiv');
+  charts.forEach(function(chart) {
+    chart.parentNode.removeChild(chart);
+    window.chartWindow = undefined;
+  });
+});
 
 </script>
 
@@ -673,8 +800,25 @@ $sciname = get_sci_name($name);
 $sciname_name = $sciname . '_' . $name;
 $info_url = get_info_url($sciname);
 $url = $info_url['URL'];
+$url_title = $info_url['TITLE'];
+$image_html = '';
+$image_provider_name = strtolower($config["IMAGE_PROVIDER"] ?? 'wikipedia');
+if ($image_provider_name === 'flickr' && ! empty($config["FLICKR_API_KEY"])) {
+  $image_provider = new Flickr();
+  if (isset($_SESSION["FLICKR_FILTER_EMAIL"]) && $_SESSION["FLICKR_FILTER_EMAIL"] !== $image_provider->get_uid_from_db()['uid']) {
+    $_SESSION["FLICKR_FILTER_EMAIL"] = $image_provider->get_uid_from_db()['uid'];
+  }
+  $cache = $image_provider->get_image($sciname);
+} else {
+  $image_provider = new Wikipedia();
+  $cache = $image_provider->get_image($sciname);
+}
+if (!empty($cache['image_url'])) {
+  $image_html = "<img class='species-thumb' onclick=\"showSpeciesModal('".urlencode($cache['title'])."','".$cache['photos_url']."','".$cache['author_url']."','".$cache['image_url']."','".$cache['license_url']."')\" src='".$cache['image_url']."'>";
+}
+$comnamegraph = str_replace("'", "\\'", $name);
 echo "<table>
-  <tr><th>$name<span style=\"font-weight:normal;\">
+  <tr><th>".$image_html."$name<span style=\"font-weight:normal;\">
   <img style='display: inline; cursor: pointer; max-width: 12px; max-height: 12px;' src=";
   if ($confirmspecies_enabled == 1) { if (in_array(str_replace("'", "", $sciname_name), $confirmed_species)) {
     echo "\"images/check.svg\" onclick='confirmspecies(\"".str_replace("'", "", $sciname_name)."\",\"del\")'";
@@ -684,7 +828,7 @@ echo "<table>
 echo "><br><i>$sciname</i></span><br>
     <a href=\"$url\" target=\"_blank\"><img title=\"$url_title\" src=\"images/info.png\" width=\"20\"></a>
     <a href=\"https://wikipedia.org/wiki/$sciname\" target=\"_blank\"><img title=\"Wikipedia\" src=\"images/wiki.png\" width=\"20\"></a>
-  </th></tr>";
+    <img style=\"cursor:pointer;float:unset;display:inline\" title=\"View species stats\" onclick=\"generateMiniGraph(this, '$comnamegraph')\" width=20 src=\"images/chart.svg\"></th></tr>";
   $iter=0;
   $iter_additional=false;
   while($results=$result2->fetchArray(SQLITE3_ASSOC))

--- a/scripts/stats.php
+++ b/scripts/stats.php
@@ -156,6 +156,8 @@ if (get_included_files()[0] === __FILE__) {
   <button onclick="hideDialog()">Close</button>
 </dialog>
 <script src="static/dialog-polyfill.js"></script>
+<script src="static/Chart.bundle.js"></script>
+<script src="static/chartjs-plugin-trendline.min.js"></script>
 <script src="static/custom-audio-player.js" defer></script>
 <script>
 var dialog = document.querySelector('dialog');
@@ -174,6 +176,111 @@ function setModalText(iter, title, text, authorlink) {
   document.getElementById('modalText').innerHTML = "<div style='white-space:nowrap'>Image link: <a target='_blank' href="+text+">"+text+"</a><br>Author link: <a target='_blank' href="+authorlink+">"+authorlink+"</a></div>";
   showDialog();
 }
+
+function showSpeciesModal(title, text, authorlink, photolink, licenseurl) {
+  document.getElementById('modalHeading').innerHTML = "Photo: \""+decodeURIComponent(title.replaceAll("+"," "))+"\" Attribution";
+  document.getElementById('modalText').innerHTML = "<div><img style='border-radius:5px;max-height: calc(100vh - 15rem);display:block;margin:0 auto;' src='"+photolink+"'></div><br><div style='white-space:nowrap'>Image link: <a target='_blank' href="+text+">"+text+"</a><br>Author link: <a target='_blank' href="+authorlink+">"+authorlink+"</a><br>License URL: <a target='_blank' href="+licenseurl+">"+licenseurl+"</a></div>";
+  showDialog();
+}
+
+function generateMiniGraph(elem, comname, days = 30) {
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', '/todays_detections.php?comname=' + comname + '&days=' + days);
+  xhr.onload = function() {
+    if (xhr.status === 200) {
+      var detections = JSON.parse(xhr.responseText);
+      if (typeof(window.chartWindow) != 'undefined') {
+        document.body.removeChild(window.chartWindow);
+        window.chartWindow = undefined;
+      }
+      var chartWindow = document.createElement('div');
+      chartWindow.className = "chartdiv";
+      document.body.appendChild(chartWindow);
+
+      var canvas = document.createElement('canvas');
+      chartWindow.appendChild(canvas);
+
+      var range = document.createElement('div');
+      range.className = 'graph-range';
+      range.innerHTML = "<span data-days='30'>1m</span> | <span data-days='180'>3m</span> | <span data-days='360'>1y</span>";
+      range.addEventListener('click', function(ev){
+        if (ev.target.dataset.days) {
+          generateMiniGraph(elem, comname, ev.target.dataset.days);
+        }
+      });
+      chartWindow.appendChild(range);
+
+      canvas.width = chartWindow.offsetWidth;
+      canvas.height = chartWindow.offsetHeight - range.offsetHeight;
+
+      var ctx = canvas.getContext('2d');
+      var chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: detections.map(item => item.date),
+          datasets: [{
+            label: 'Detections',
+            data: detections.map(item => item.count),
+            backgroundColor: '#9fe29b',
+            borderColor: '#77c487',
+            borderWidth: 1,
+            lineTension: 0.3,
+            pointRadius: 1,
+            pointHitRadius: 10,
+            trendlineLinear: {
+              style: "rgba(55, 99, 64, 0.5)",
+              lineStyle: "solid",
+              width: 1.5
+            }
+          }]
+        },
+        options: {
+          layout: { padding: { right: 10 } },
+          title: { display: true, text: 'Detections Over ' + days + 'd' },
+          legend: { display: false },
+          scales: {
+            xAxes: [{ display: false, gridLines: { display: false }, ticks: { autoSkip: true, maxTicksLimit: 2 } }],
+            yAxes: [{ gridLines: { display: false }, ticks: { beginAtZero: true, precision: 0, stepSize: 1 } }]
+          }
+        }
+      });
+
+      var buttonRect = elem.getBoundingClientRect();
+      var chartRect = chartWindow.getBoundingClientRect();
+      if (window.innerWidth < 700) {
+        chartWindow.style.left = 'calc(75% - ' + (chartRect.width / 2) + 'px)';
+      } else {
+        chartWindow.style.left = (buttonRect.right + 10) + 'px';
+      }
+      var buttonCenter = buttonRect.top + (buttonRect.height / 2);
+      var chartHeight = chartWindow.offsetHeight;
+      var chartTop = buttonCenter - (chartHeight / 2);
+      chartWindow.style.top = chartTop + 'px';
+
+      var closeButton = document.createElement('button');
+      closeButton.id = "chartcb";
+      closeButton.innerText = 'X';
+      closeButton.style.position = 'absolute';
+      closeButton.style.top = '5px';
+      closeButton.style.right = '5px';
+      closeButton.addEventListener('click', function() {
+        document.body.removeChild(chartWindow);
+        window.chartWindow = undefined;
+      });
+      chartWindow.appendChild(closeButton);
+      window.chartWindow = chartWindow;
+    }
+  };
+  xhr.send();
+}
+
+window.addEventListener('scroll', function() {
+  var charts = document.querySelectorAll('.chartdiv');
+  charts.forEach(function(chart) {
+    chart.parentNode.removeChild(chart);
+    window.chartWindow = undefined;
+  });
+});
 </script>  
 <div class="column center">
 <?php if(!isset($_GET['species'])){
@@ -183,6 +290,15 @@ function setModalText(iter, title, text, authorlink) {
 <?php if(isset($_GET['species'])){
   $species = $_GET['species'];
   $iter=0;
+  $image_provider = null;
+  if ($image_provider_name === 'flickr' && ! empty($config["FLICKR_API_KEY"])) {
+    $image_provider = new Flickr();
+    if (isset($_SESSION["FLICKR_FILTER_EMAIL"]) && $_SESSION["FLICKR_FILTER_EMAIL"] !== $image_provider->get_uid_from_db()['uid']) {
+      $_SESSION["FLICKR_FILTER_EMAIL"] = $image_provider->get_uid_from_db()['uid'];
+    }
+  } else {
+    $image_provider = new Wikipedia();
+  }
 while($results=$result3->fetchArray(SQLITE3_ASSOC)){
   $count = $results['COUNT(*)'];
   $maxconf = round((float)round($results['MAX(Confidence)'],2) * 100 ) . '%';
@@ -200,19 +316,14 @@ while($results=$result3->fetchArray(SQLITE3_ASSOC)){
   $info_url = get_info_url($results['Sci_Name']);
   $url = $info_url['URL'];
   $url_title = $info_url['TITLE'];
-  echo str_pad("<h3>$species</h3>
-    <table><tr>
-  <td class=\"relative\"><a target=\"_blank\" href=\"index.php?filename=".$results['File_Name']."\"><img title=\"Open in new tab\" class=\"copyimage\" width=25 src=\"images/copy.png\"></a><i>$sciname</i>
-  <a href=\"$url\" target=\"_blank\"><img style=\"width: unset !important; display: inline; height: 1em; cursor: pointer;\" title=\"$url_title\" src=\"images/info.png\" width=\"20\"></a>
-  <a href=\"https://wikipedia.org/wiki/$sciname\" target=\"_blank\"><img style=\"width: unset !important; display: inline; height: 1em; cursor: pointer;\" title=\"Wikipedia\" src=\"images/wiki.png\" width=\"20\"></a><br>
-  Occurrences: $count<br>
-  Max Confidence: $maxconf<br>
-  Best Recording: $date $time<br><br>
-  <div class='custom-audio-player' data-audio-src=\"$filename\" data-image-src=\"$filename.png\"></div>
-  </tr>
-    </table>
-  <p>Loading Images from ".ucfirst($image_provider_name)."</p>", '6096');
-  
+  $cache = $image_provider->get_image($sciname);
+  $image_html = '';
+  if (!empty($cache['image_url'])) {
+  $image_html = "<img class='species-thumb' onclick=\"showSpeciesModal('".urlencode($cache['title'])."','{$cache['photos_url']}','{$cache['author_url']}','{$cache['image_url']}','{$cache['license_url']}')\" src='{$cache['image_url']}'>";
+  }
+  $comnamegraph = str_replace("'", "\\'", $species);
+  echo str_pad("<h3>$species</h3>".
+    "<table><tr>\n  <td class=\"relative\">".$image_html."<a target=\"_blank\" href=\"index.php?filename=".$results['File_Name']."\"><img title=\"Open in new tab\" class=\"copyimage\" width=25 src=\"images/copy.png\"></a><i>$sciname</i>\n  <a href=\"$url\" target=\"_blank\"><img style=\"width: unset !important; display: inline; height: 1em; cursor: pointer;\" title=\"$url_title\" src=\"images/info.png\" width=\"20\"></a>\n  <a href=\"https://wikipedia.org/wiki/$sciname\" target=\"_blank\"><img style=\"width: unset !important; display: inline; height: 1em; cursor: pointer;\" title=\"Wikipedia\" src=\"images/wiki.png\" width=\"20\"></a><img style=\"width: unset !important; display: inline; height: 1em; cursor:pointer\" title=\"View species stats\" onclick=\"generateMiniGraph(this, '$comnamegraph')\" width=\"20\" src=\"images/chart.svg\"><br>\n  Occurrences: $count<br>\n  Max Confidence: $maxconf<br>\n  Best Recording: $date $time<br><br>\n  <div class='custom-audio-player' data-audio-src=\"$filename\" data-image-src=\"$filename.png\"></div>\n  </tr>\n    </table>\n  <p>Loading Images from ".ucfirst($image_provider_name)."</p>", '6096');
   echo "<script>document.getElementsByTagName(\"h3\")[0].scrollIntoView();</script>";
   
   ob_flush();

--- a/scripts/todays_detections.php
+++ b/scripts/todays_detections.php
@@ -267,7 +267,7 @@ if(isset($_GET['ajax_detections']) && $_GET['ajax_detections'] == "true"  ) {
           <div>
             <div>
             <?php if($image_provider !== null && (isset($_GET['hard_limit']) || $_GET['kiosk'] == true) && strlen($image[2]) > 0) { ?>
-              <img style="float:left;height:75px;" onclick='setModalText(<?php echo $iterations; ?>,"<?php echo urlencode($image[2]); ?>", "<?php echo $image[3]; ?>", "<?php echo $image[4]; ?>", "<?php echo $image[1]; ?>", "<?php echo $image[5]; ?>")' src="<?php echo $image[1]; ?>" id="birdimage" class="img1">
+              <img class="img1 species-thumb" onclick='setModalText(<?php echo $iterations; ?>,"<?php echo urlencode($image[2]); ?>", "<?php echo $image[3]; ?>", "<?php echo $image[4]; ?>", "<?php echo $image[1]; ?>", "<?php echo $image[5]; ?>")' src="<?php echo $image[1]; ?>" id="birdimage">
             <?php } ?>
           </div>
             <div>
@@ -577,10 +577,10 @@ window.addEventListener("load", function(){
 
 <script src="static/custom-audio-player.js"></script>
 <script>
-function generateMiniGraph(elem, comname) {
+function generateMiniGraph(elem, comname, days = 30) {
   // Make an AJAX call to fetch the number of detections for the bird species
   var xhr = new XMLHttpRequest();
-  xhr.open('GET', '/todays_detections.php?comname=' + comname);
+  xhr.open('GET', '/todays_detections.php?comname=' + comname + '&days=' + days);
   xhr.onload = function() {
     if (xhr.status === 200) {
       var detections = JSON.parse(xhr.responseText);
@@ -597,9 +597,21 @@ function generateMiniGraph(elem, comname) {
 
             // Create a canvas element for the chart
       var canvas = document.createElement('canvas');
-      canvas.width = chartWindow.offsetWidth;
-      canvas.height = chartWindow.offsetHeight;
       chartWindow.appendChild(canvas);
+
+      // Add range selector
+      var range = document.createElement('div');
+      range.className = 'graph-range';
+      range.innerHTML = "<span data-days='30'>1m</span> | <span data-days='180'>3m</span> | <span data-days='360'>1y</span>";
+      range.addEventListener('click', function(ev) {
+        if (ev.target.dataset.days) {
+          generateMiniGraph(elem, comname, ev.target.dataset.days);
+        }
+      });
+      chartWindow.appendChild(range);
+
+      canvas.width = chartWindow.offsetWidth;
+      canvas.height = chartWindow.offsetHeight - range.offsetHeight;
 
       // Create a new Chart.js chart
       var ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- show species thumbnail and modal in recordings and stats views
- add graph icon with selectable range (1m/3m/1y) across species pages
- update shared graph function with range selector
- standardize thumbnail size and enlarge mini graphs for range selector

## Testing
- `php -l scripts/play.php`
- `php -l scripts/stats.php`
- `php -l scripts/todays_detections.php`
- `php -l scripts/overview.php`
- `pytest` *(fails: ModuleNotFoundError: No module named 'apprise')*


------
https://chatgpt.com/codex/tasks/task_e_68959c172be483258eb70b62f276bac9