### PR TITLE
docs: mention Telegram markdown requirement

### DIFF
--- a/scripts/config.php
+++ b/scripts/config.php
@@ -486,10 +486,10 @@ function runProcess() {
       </td></tr></table><br>
       <table class="settingstable" style="width:100%"><tr><td>
       <h2>Notifications</h2>
-      <p><a target="_blank" href="https://github.com/caronc/apprise/wiki">Apprise Notifications</a> can be setup and enabled for 90+ notification services. Each service should be on its own line.</p>
+      <p><a target="_blank" href="https://github.com/caronc/apprise/wiki">Apprise Notifications</a> can be setup and enabled for 90+ notification services. Each service should be on its own line. For Telegram add "?format=markdown" after your chat_id</p>
       <label for="apprise_input">Apprise Notifications Configuration: </label><br>
       <textarea placeholder="mailto://{user}:{password}@gmail.com
-tgram://{bot_token}/{chat_id}
+tgram://{bot_token}/{chat_id}?format=markdown (?format=markdown needed for weekly report)
 twitter://{ConsumerKey}/{ConsumerSecret}/{AccessToken}/{AccessSecret}
 https://discordapp.com/api/webhooks/{WebhookID}/{WebhookToken}
 ..." style="vertical-align: top" class="testbtn" name="apprise_input" rows="5" type="text" ><?php print($apprise_config);?></textarea>


### PR DESCRIPTION
## Summary
- document that Apprise Telegram URLs require `?format=markdown` for weekly reports

## Testing
- `python3 -m pytest` *(fails: AssertionError: 'A Great Crested Flycatcher...0.91' == 'A Great Crested Flycatcher...91 (first time today)')*

------
https://chatgpt.com/codex/tasks/task_e_68a9971b72288325b73d7f7a2ba9679a