### PR TITLE
Open species tools DB read-only unless deleting

### DIFF
--- a/scripts/species_tools.php
+++ b/scripts/species_tools.php
@@ -7,7 +7,9 @@ require_once __DIR__ . '/common.php';
 ensure_authenticated();
 
 $home = get_home();
-$db   = new SQLite3(__DIR__ . '/birds.db', SQLITE3_OPEN_READWRITE);
+// Open database read-only for typical operations; enable writes only for deletions
+$flags = isset($_GET['delete']) ? SQLITE3_OPEN_READWRITE : SQLITE3_OPEN_READONLY;
+$db   = new SQLite3(__DIR__ . '/birds.db', $flags);
 $db->busyTimeout(1000);
 
 /* Paths / lists */


### PR DESCRIPTION
## Summary
- Open `scripts/species_tools.php` database connection in read-only mode by default
- Switch to read-write mode when a deletion is requested

## Testing
- `php -l scripts/species_tools.php`
- `pytest -q` *(fails: AssertionError in tests/test_apprise_notifications.py::test_notifications)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5b3bab8c832596c8a6c22b966d7f