### PR TITLE
Add disk file counts column

### DIFF
--- a/scripts/species_tools.php
+++ b/scripts/species_tools.php
@@ -165,6 +165,26 @@ if (isset($_GET['delete'])) {
   echo json_encode(['lines' => $lines_deleted, 'files' => $deleted]); exit;
 }
 
+/* ---------- disk species counts ---------- */
+if (isset($_GET['diskcounts'])) {
+  header('Content-Type: application/json');
+  $script = __DIR__ . '/disk_species_count.sh';
+  $output = @shell_exec('bash ' . escapeshellarg($script) . ' 2>&1');
+  $counts = [];
+  if ($output !== null) {
+    foreach (preg_split('/\r?\n/', $output) as $line) {
+      $line = trim($line);
+      if ($line === '') continue;
+      if (preg_match('/^([0-9]+(?:\.[0-9]+)?)(k?)\s*:\s*(.+)$/i', $line, $m)) {
+        $num = (float)$m[1];
+        if (strtolower($m[2]) === 'k') $num *= 1000;
+        $counts[$m[3]] = (int)round($num);
+      }
+    }
+  }
+  echo json_encode($counts, JSON_UNESCAPED_UNICODE); exit;
+}
+
 /* ---------- query species aggregates ---------- */
 $sql = <<<SQL
 SELECT
@@ -192,6 +212,7 @@ $result = $db->query($sql);
   <div class="toolbar">
     <input id="q" type="text" placeholder="Filter species… (name, scientific)"
            title="Type to filter; persists across reloads">
+    <button id="loadDiskCounts" type="button">Disk Files</button>
     <small id="matchCount"></small>
   </div>
 
@@ -317,6 +338,32 @@ function deleteSpecies(species) {
   });
 }
 
+// ---------- disk counts column ----------
+function addDiskCounts() {
+  get(scriptsBase + 'species_tools.php?diskcounts=1').then(t => {
+    let counts; try { counts = JSON.parse(t); } catch { alert('Could not parse disk counts'); return; }
+    const table = document.getElementById('speciesTable');
+    const headerRow = table.tHead.rows[0];
+    const deleteHeader = headerRow.lastElementChild;
+    const th = document.createElement('th');
+    th.textContent = 'Files on Disk';
+    headerRow.insertBefore(th, deleteHeader);
+    const colIndex = headerRow.cells.length - 2;
+    th.addEventListener('click', () => sortTable(colIndex));
+    const decoder = document.createElement('textarea');
+    document.querySelectorAll('#speciesTable tbody tr').forEach(tr => {
+      decoder.innerHTML = tr.getAttribute('data-comname') || '';
+      const name = decoder.value;
+      const count = counts[name] || 0;
+      const td = document.createElement('td');
+      td.textContent = count;
+      td.dataset.sort = count;
+      tr.insertBefore(td, tr.lastElementChild);
+    });
+    document.getElementById('loadDiskCounts').disabled = true;
+  });
+}
+
 // ---------- Sorting with persistence ----------
 function sortTable(n) {
   const table = document.getElementById('speciesTable');
@@ -373,5 +420,6 @@ document.addEventListener('DOMContentLoaded', () => {
   try { const saved = localStorage.getItem('speciesFilter'); if (saved !== null) q.value = saved; } catch(e){}
   applyFilter();
   applySavedSort();
+  document.getElementById('loadDiskCounts').addEventListener('click', addDiskCounts);
 });
 </script>


### PR DESCRIPTION
## Summary
- add API endpoint to fetch per-species disk file counts from `disk_species_count.sh`
- add "Disk Files" button that loads counts and inserts sortable column

## Testing
- `php -l scripts/species_tools.php`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'apprise')*
- `scripts/disk_species_count.sh >/tmp/diskcount.log && tail -n 20 /tmp/diskcount.log` *(missing /etc/birdnet/birdnet.conf)*

------
https://chatgpt.com/codex/tasks/task_e_68adabe8289c83258b3013b6fbe94268