### PR TITLE
feat: interactive daily detections chart

### DIFF
--- a/homepage/static/daily_plot.js
+++ b/homepage/static/daily_plot.js
@@ -1,0 +1,89 @@
+function renderDailyPlot(data) {
+  const container = document.getElementById('daily-plot');
+  if (!container) return;
+  const table = document.createElement('table');
+  table.id = 'daily-plot-table';
+
+  const headers = ['Common Name', 'Max Confidence', 'Occurrences'];
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  headers.forEach((h, idx) => {
+    const th = document.createElement('th');
+    th.textContent = h;
+    th.addEventListener('click', () => sortTable(idx));
+    headerRow.appendChild(th);
+  });
+  for (let h = 0; h < 24; h++) {
+    const th = document.createElement('th');
+    th.textContent = h.toString().padStart(2, '0');
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  let max = 0;
+  data.species.forEach(sp => {
+    sp.hours.forEach(c => { if (c > max) max = c; });
+  });
+
+  data.species.forEach(sp => {
+    const tr = document.createElement('tr');
+    const tdName = document.createElement('td');
+    tdName.textContent = sp.name;
+    tr.appendChild(tdName);
+    const tdConf = document.createElement('td');
+    tdConf.textContent = Number(sp.max_confidence).toFixed(2);
+    tr.appendChild(tdConf);
+    const tdTotal = document.createElement('td');
+    tdTotal.textContent = sp.total;
+    tr.appendChild(tdTotal);
+    sp.hours.forEach((count, hour) => {
+      const td = document.createElement('td');
+      if (count) {
+        const alpha = max ? (count / max) : 0;
+        td.style.backgroundColor = `rgba(76,175,80,${alpha})`;
+        td.textContent = count;
+      }
+      td.title = `${sp.name} - ${count} detections - max conf ${sp.max_confidence.toFixed(2)}`;
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  container.innerHTML = '';
+  container.appendChild(table);
+}
+
+function sortTable(idx) {
+  const table = document.getElementById('daily-plot-table');
+  const tbody = table.tBodies[0];
+  const rows = Array.from(tbody.rows);
+  const asc = table.dataset.sortAsc === '1' ? false : true;
+  rows.sort((a, b) => {
+    let valA = a.cells[idx].textContent;
+    let valB = b.cells[idx].textContent;
+    if (idx > 0) {
+      valA = parseFloat(valA) || 0;
+      valB = parseFloat(valB) || 0;
+    }
+    return asc ? (valA > valB ? 1 : -1) : (valA < valB ? 1 : -1);
+  });
+  rows.forEach(r => tbody.appendChild(r));
+  table.dataset.sortAsc = asc ? '1' : '0';
+}
+
+function loadDailyPlot(date) {
+  const container = document.getElementById('daily-plot');
+  if (!container) return;
+  fetch(`scripts/daily_plot_data.php?date=${date}`)
+    .then(resp => resp.json())
+    .then(data => renderDailyPlot(data))
+    .catch(() => { container.textContent = 'No data available'; });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('daily-plot');
+  if (!container) return;
+  loadDailyPlot(container.dataset.date);
+});

--- a/scripts/daily_plot_data.php
+++ b/scripts/daily_plot_data.php
@@ -1,0 +1,42 @@
+<?php
+
+/* Prevent XSS input */
+$_GET   = filter_input_array(INPUT_GET, FILTER_SANITIZE_STRING);
+$_POST  = filter_input_array(INPUT_POST, FILTER_SANITIZE_STRING);
+
+require_once 'scripts/common.php';
+set_timezone();
+
+$date = isset($_GET['date']) ? $_GET['date'] : date('Y-m-d');
+
+$db = new SQLite3('./scripts/birds.db', SQLITE3_OPEN_READONLY);
+$db->busyTimeout(1000);
+
+$statement = $db->prepare('SELECT Com_Name, CAST(strftime("%H", Time) as INTEGER) AS Hour, COUNT(*) AS Count, MAX(Confidence) AS MaxConf FROM detections WHERE Date == :date GROUP BY Com_Name, Hour');
+$statement->bindValue(':date', $date, SQLITE3_TEXT);
+ensure_db_ok($statement);
+$result = $statement->execute();
+
+$data = [];
+while($row = $result->fetchArray(SQLITE3_ASSOC)) {
+    $name = $row['Com_Name'];
+    $hour = intval($row['Hour']);
+    $count = intval($row['Count']);
+    $conf = floatval($row['MaxConf']);
+    if(!isset($data[$name])) {
+        $data[$name] = [
+            'name' => $name,
+            'max_confidence' => $conf,
+            'total' => 0,
+            'hours' => array_fill(0, 24, 0)
+        ];
+    }
+    $data[$name]['hours'][$hour] = $count;
+    $data[$name]['total'] += $count;
+    if($conf > $data[$name]['max_confidence']) {
+        $data[$name]['max_confidence'] = $conf;
+    }
+}
+
+header('Content-Type: application/json');
+echo json_encode(['date' => $date, 'species' => array_values($data)]);

--- a/scripts/overview.php
+++ b/scripts/overview.php
@@ -10,7 +10,6 @@ $config = get_config();
 
 set_timezone();
 $myDate = date('Y-m-d');
-$chart = "Combo-$myDate.png";
 
 $db = new SQLite3('./scripts/birds.db', SQLITE3_OPEN_READONLY);
 $db->busyTimeout(1000);
@@ -44,12 +43,6 @@ if(isset($_GET['blacklistimage'])) {
   die("OK");
 }
 
-if(isset($_GET['fetch_chart_string']) && $_GET['fetch_chart_string'] == "true") {
-  $myDate = date('Y-m-d');
-  $chart = "Combo-$myDate.png";
-  echo $chart;
-  die();
-}
 
 if(isset($_GET['ajax_detections']) && $_GET['ajax_detections'] == "true" && isset($_GET['previous_detection_identifier'])) {
 
@@ -465,19 +458,8 @@ function display_species($species_list, $title, $show_last_seen=false) {
 display_species($new_species, 'New Species');
 display_species($rare_species, 'Rare Species', true);
 ?>
-<div class="chart">
-<?php
-$refresh = $config['RECORDING_LENGTH'];
-$dividedrefresh = $refresh/4;
-if($dividedrefresh < 1) { 
-  $dividedrefresh = 1;
-}
-$time = time();
-if (file_exists('./Charts/'.$chart)) {
-  echo "<img id='chart' src=\"Charts/$chart?nocache=$time\">";
-} 
-?>
-</div>
+<div class="chart" id="daily-plot" data-date="<?php echo $myDate; ?>"></div>
+<script src="static/daily_plot.js"></script>
 
 <div id="most_recent_detection"></div>
 <br>
@@ -541,14 +523,10 @@ function loadCenterChart() {
   xhttp.send();
 }
 function refreshTopTen() {
-  const xhttp = new XMLHttpRequest();
-  xhttp.onload = function() {
-  if(this.responseText.length > 0 && !this.responseText.includes("Database is busy") && !this.responseText.includes("No Detections") || previous_detection_identifier == undefined) {
-    if (document.getElementById("chart")) {document.getElementById("chart").src = "Charts/"+this.responseText+"?nocache="+Date.now();}
+  const container = document.getElementById("daily-plot");
+  if (container && typeof loadDailyPlot === "function") {
+    loadDailyPlot(container.dataset.date);
   }
-  }
-  xhttp.open("GET", "overview.php?fetch_chart_string=true", true);
-  xhttp.send();
 }
 function refreshDetection() {
   if (!document.hidden) {


### PR DESCRIPTION
## Summary
- Render hourly detection heatmap on overview page only
- Keep history page's original PNG charts
- Expose loadDailyPlot helper for dynamic refresh

## Testing
- `php -l scripts/overview.php`
- `php -l scripts/history.php`
- `php -l scripts/daily_plot_data.php`
- `pytest` *(fails: AssertionError: assert 0 == 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ad775d7e648325a55dd7295535dd62