### PR TITLE
Add manual observation.org upload option

### DIFF
--- a/homepage/images/upload.svg
+++ b/homepage/images/upload.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+  <path d='M12 19V6'/>
+  <path d='M5 12l7-7 7 7'/>
+  <path d='M5 19h14'/>
+</svg>

--- a/scripts/observation_upload.php
+++ b/scripts/observation_upload.php
@@ -1,0 +1,67 @@
+<?php
+/* Prevent XSS input */
+$_GET  = filter_input_array(INPUT_GET, FILTER_SANITIZE_STRING);
+$_POST = filter_input_array(INPUT_POST, FILTER_SANITIZE_STRING);
+
+require_once 'scripts/common.php';
+$home   = get_home();
+$config = get_config();
+
+// Connect to database
+$db = new SQLite3('./scripts/birds.db', SQLITE3_OPEN_READONLY);
+$db->busyTimeout(1000);
+
+if(isset($_GET['filename'])) {
+    $name = $_GET['filename'];
+    $fileBase = basename($name);
+
+    $statement = $db->prepare('SELECT * FROM detections WHERE File_name == :file LIMIT 1');
+    ensure_db_ok($statement);
+    $statement->bindValue(':file', $fileBase, SQLITE3_TEXT);
+    $result = $statement->execute();
+    $details = $result->fetchArray(SQLITE3_ASSOC);
+
+    if($details) {
+        $date = $details['Date'];
+        $time = $details['Time'];
+        $lat  = $details['Lat'];
+        $lon  = $details['Lon'];
+        $species = $details['Com_Name'];
+
+        $query = http_build_query([
+            'species' => $species,
+            'date'    => $date,
+            'time'    => $time,
+            'lat'     => $lat,
+            'lon'     => $lon
+        ]);
+        $obsUrl = 'https://observation.org/observation/create?' . $query;
+        $audioPath = '../BirdSongs/Extracted/By_Date/' . $name;
+    } else {
+        $obsUrl = '';
+        $audioPath = '';
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset='utf-8'>
+<title>Upload observation</title>
+</head>
+<body>
+<script>
+window.onload = function() {
+<?php if(!empty($obsUrl)): ?>
+  window.open('<?php echo $obsUrl; ?>', '_blank');
+  var link = document.createElement('a');
+  link.href = '<?php echo $audioPath; ?>';
+  link.download = '<?php echo basename($name ?? 'audio.mp3'); ?>';
+  document.body.appendChild(link);
+  link.click();
+<?php endif; ?>
+};
+</script>
+<p>Preparing observation...</p>
+</body>
+</html>

--- a/scripts/play.php
+++ b/scripts/play.php
@@ -259,6 +259,10 @@ function toggleShiftFreq(filename, shiftAction, elem) {
   elem.setAttribute("src","images/spinner.gif");
 }
 
+function uploadObservation(filename) {
+  window.open("observation_upload.php?filename=" + encodeURIComponent(filename), "_blank");
+}
+
 function changeDetection(filename,copylink=false) {
   const xhttp = new XMLHttpRequest();
   xhttp.onload = function() {
@@ -602,9 +606,10 @@ echo "<table>
       echo "<tr>
   <td class=\"relative\"> 
 
-<img style='cursor:pointer;right:120px' src='images/delete.svg' onclick='deleteDetection(\"".$filename_formatted."\")' class=\"copyimage\" width=25 title='Delete Detection'> 
-<img style='cursor:pointer;right:85px' src='images/bird.svg' onclick='changeDetection(\"".$filename_formatted."\")' class=\"copyimage\" width=25 title='Change Detection'> 
-<img style='cursor:pointer;right:45px' onclick='toggleLock(\"".$filename_formatted."\",\"".$type."\", this)' class=\"copyimage\" width=25 title=\"".$title."\" src=\"".$imageicon."\"> 
+<img style='cursor:pointer;right:160px' src='images/upload.svg' onclick='uploadObservation(\"".$filename_formatted."\")' class=\"copyimage\" width=25 title='Upload to observation.org'>
+<img style='cursor:pointer;right:120px' src='images/delete.svg' onclick='deleteDetection(\"".$filename_formatted."\")' class=\"copyimage\" width=25 title='Delete Detection'>
+<img style='cursor:pointer;right:85px' src='images/bird.svg' onclick='changeDetection(\"".$filename_formatted."\")' class=\"copyimage\" width=25 title='Change Detection'>
+<img style='cursor:pointer;right:45px' onclick='toggleLock(\"".$filename_formatted."\",\"".$type."\", this)' class=\"copyimage\" width=25 title=\"".$title."\" src=\"".$imageicon."\">
 <img style='cursor:pointer' onclick='toggleShiftFreq(\"".$filename_formatted."\",\"".$shiftAction."\", this)' class=\"copyimage\" width=25 title=\"".$shiftTitle."\" src=\"".$shiftImageIcon."\"> $date $time<br>$values<br>
 
         ".$imageelem."
@@ -694,9 +699,10 @@ echo "<table>
           echo "<tr>
       <td class=\"relative\"> 
 
-<img style='cursor:pointer;right:120px' src='images/delete.svg' onclick='deleteDetection(\"".$filename_formatted."\", true)' class=\"copyimage\" width=25 title='Delete Detection'> 
-<img style='cursor:pointer;right:85px' src='images/bird.svg' onclick='changeDetection(\"".$filename_formatted."\")' class=\"copyimage\" width=25 title='Change Detection'> 
-<img style='cursor:pointer;right:45px' onclick='toggleLock(\"".$filename_formatted."\",\"".$type."\", this)' class=\"copyimage\" width=25 title=\"".$title."\" src=\"".$imageicon."\"> 
+<img style='cursor:pointer;right:160px' src='images/upload.svg' onclick='uploadObservation(\"".$filename_formatted."\")' class=\"copyimage\" width=25 title='Upload to observation.org'>
+<img style='cursor:pointer;right:120px' src='images/delete.svg' onclick='deleteDetection(\"".$filename_formatted."\", true)' class=\"copyimage\" width=25 title='Delete Detection'>
+<img style='cursor:pointer;right:85px' src='images/bird.svg' onclick='changeDetection(\"".$filename_formatted."\")' class=\"copyimage\" width=25 title='Change Detection'>
+<img style='cursor:pointer;right:45px' onclick='toggleLock(\"".$filename_formatted."\",\"".$type."\", this)' class=\"copyimage\" width=25 title=\"".$title."\" src=\"".$imageicon."\">
 <img style='cursor:pointer' onclick='toggleShiftFreq(\"".$filename_formatted."\",\"".$shiftAction."\", this)' class=\"copyimage\" width=25 title=\"".$shiftTitle."\" src=\"".$shiftImageIcon."\">$date $time<br>$values<br>
 
 <div class='custom-audio-player' data-audio-src='$filename' data-image-src='$filename_png'></div>


### PR DESCRIPTION
## Summary
- Add script to prefill observation.org submission and trigger audio file download
- Expose upload button in recording list linking to observation.org
- Include upload icon asset

## Testing
- `pytest -q` *(fails: fixture 'mocker' not found / FileNotFoundError; after installing deps fails assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ac5657a48325804e66acfc890468